### PR TITLE
Fix stakers count

### DIFF
--- a/manifests/astar.yaml
+++ b/manifests/astar.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: dapps-staking-indexer-astar
-version: 3
+version: 5
 description: "ArrowSquid Indexer for Dapps Staking V3"
 build:
 scale:

--- a/manifests/shibuya.yaml
+++ b/manifests/shibuya.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: dapps-staking-indexer-shibuya
-version: 4
+version: 5
 description: "ArrowSquid Indexer for Dapps Staking V3"
 build:
 scale:

--- a/manifests/shiden.yaml
+++ b/manifests/shiden.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: dapps-staking-indexer-shiden
-version: 3
+version: 5
 description: "ArrowSquid Indexer for Dapps Staking V3"
 build:
 scale:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "generate-metadata": "squid-substrate-metadata-explorer --rpc ws://127.0.0.1:9944 --out localNode.jsonl",
     "generate-migration": "npx squid-typeorm-migration generate",
     "apply-migration": "npx squid-typeorm-migration apply",
+    "deploy:astar": "sqd deploy . --org=astar-network --manifest=manifests/astar.yaml",
     "deploy:shibuya": "sqd deploy . --org=astar-network --manifest=manifests/shibuya.yaml",
     "deploy:shiden": "sqd deploy . --org=astar-network --manifest=manifests/shiden.yaml",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dapps-staking-indexer-v3",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "engines": {
     "node": ">=16"

--- a/src/mapping/dapp.ts
+++ b/src/mapping/dapp.ts
@@ -84,16 +84,8 @@ async function updateStakersCount(
   dappAggregated: DappAggregatedDaily | undefined,
   event: Event,
   day: number,
-  stake: Stake,
-  ctx: ProcessorContext<Store>
+  stake: Stake
 ) {
-  const newSubperiod = await ctx.store.findOneBy(Subperiod, {
-    timestamp: BigInt(day),
-  });
-
-  if (newSubperiod && newSubperiod.type === SubperiodType.Voting) {
-    return;
-  }
 
   if (dappAggregated) {
     const entity = entities.StakersCountToUpdate.find(
@@ -154,19 +146,19 @@ export async function handleStakersCount(
     dapp.stakersCount++;
     await upsertStakers(entities, stake, ctx, totalStake);
     await insertUniqueStakerAddress(entities, stake, ctx);
-    await updateStakersCount(entities, dapp, dappAggregated, event, day, stake, ctx);
+    await updateStakersCount(entities, dapp, dappAggregated, event, day, stake);
     return dapp;
   } else if (dapp && totalStake === 0n) {
     // user un-stakes everything.
     dapp.stakersCount--;
     await deleteStakers(stake, ctx);
     await deleteUniqueStakerAddress(stake, ctx);
-    await updateStakersCount(entities, dapp, dappAggregated, event, day, stake, ctx);
+    await updateStakersCount(entities, dapp, dappAggregated, event, day, stake);
     return dapp;
   } else if (dapp) {
     // user stakes again after un-staking some amount.
     await upsertStakers(entities, stake, ctx, totalStake);
-    await updateStakersCount(entities, dapp, dappAggregated, event, day, stake, ctx);
+    await updateStakersCount(entities, dapp, dappAggregated, event, day, stake);
   }
 
   return undefined;


### PR DESCRIPTION
Fix stakers count from `Dapp` Entity.

There's miscalculated result on the `Dapp` Entity. the `updateStakersCount` function (which is placed to `src/mapping/dapp.ts`) is blocked to update stakers count when the subperiod is Voting.