### PR TITLE
Fix for price fetch from Coingecko

### DIFF
--- a/src/utils/getUsdPrice.ts
+++ b/src/utils/getUsdPrice.ts
@@ -55,6 +55,7 @@ export async function getUsdPrice(
       });
 
       res.on("error", (error) => {
+        console.error(`Error fetching price for ${token}:`, error);
         return reject(error);
       });
     });
@@ -63,5 +64,8 @@ export async function getUsdPrice(
 
 export function formatDate(timestamp: string) {
   const date = new Date(Number(timestamp));
-  return `${date.getDate()}-${date.getMonth() + 1}-${date.getFullYear()}`;
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }


### PR DESCRIPTION
Coingecko changed API and requires date in yyyy-mm-dd format